### PR TITLE
Replace the Cadvisor image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       mode: global
 
   cadvisor:
-    image: google/cadvisor
+    image: gcr.io/cadvisor/cadvisor
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw


### PR DESCRIPTION
The image location has been changed and the old image was deprecated as we can see in here https://hub.docker.com/r/google/cadvisor/
